### PR TITLE
Compilation fix on recent OCaml

### DIFF
--- a/src/ml_text.c
+++ b/src/ml_text.c
@@ -107,7 +107,7 @@ CAMLprim value ml_text_decode(value cd_val, value buf_val, value pos_val, value 
 {
   CAMLparam4(cd_val, buf_val, pos_val, len_val);
 
-  uint32 code;
+  uint32_t code;
   size_t len = Long_val(len_val);
   size_t in_left = len;
   char *in_bytes = String_val(buf_val) + Long_val(pos_val);
@@ -152,7 +152,7 @@ CAMLprim value ml_text_encode(value cd_val, value buf_val, value pos_val, value 
 {
   CAMLparam5(cd_val, buf_val, pos_val, len_val, code_val);
 
-  uint32 code = Int_val(code_val);
+  uint32_t code = Int_val(code_val);
   size_t len = Long_val(len_val);
   size_t in_left = 4;
   char *in_bytes = (char*)&code;

--- a/src/ml_text_bigarray.c
+++ b/src/ml_text_bigarray.c
@@ -23,7 +23,7 @@ CAMLprim value ml_text_decode_bigarray(value cd_val, value buf_val, value pos_va
 {
   CAMLparam4(cd_val, buf_val, pos_val, len_val);
 
-  uint32 code;
+  uint32_t code;
   size_t len = Long_val(len_val);
   size_t in_left = len;
   char *in_bytes = (char*)Caml_ba_data_val(buf_val) + Long_val(pos_val);
@@ -47,7 +47,7 @@ CAMLprim value ml_text_encode_bigarray(value cd_val, value buf_val, value pos_va
 {
   CAMLparam5(cd_val, buf_val, pos_val, len_val, code_val);
 
-  uint32 code = Int_val(code_val);
+  uint32_t code = Int_val(code_val);
   size_t len = Long_val(len_val);
   size_t in_left = 4;
   char *in_bytes = (char*)&code;


### PR DESCRIPTION
Since this bug was fixed: http://caml.inria.fr/mantis/view.php?id=6517
we should use uint32_t rather than uint32

Signed-off-by: Jon Ludlam jonathan.ludlam@citrix.com
