### PR TITLE
Add musl paths to the iconv search list

### DIFF
--- a/setup.ml
+++ b/setup.ml
@@ -7287,6 +7287,8 @@ let setup () = BaseSetup.setup setup_t;;
 
 (* List of paths to search for iconv *)
 let search_paths = [
+  "/usr/include/x86_64-linux-musl/"; (* Debian *)
+  "/usr/x86_64-linux-musl/";         (* RedHat *)
   "/usr";
   "/usr/local";
   "/opt";


### PR DESCRIPTION
OCaml officially supports a [musl](https://musl-libc.org) flavor, but ocaml-text is currently unusable with it.

The issue is that musl provides its own implementation of libiconv integrated into the main static library, but `setup.ml` of ocaml-text does not search musl library paths for it and assumes that libiconv is not available.

This patch works around the issue by adding typical musl paths to the lookup list. I've added paths used by Debian and Fedora/RHEL derivcatives, which should cover most systems I hope. 